### PR TITLE
🐛 fix: read value from custom method first

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -19,15 +19,16 @@ func nestedValue(ctx context.Context, any interface{}, chainingAttrs []string) (
 
 	rv := reflect.ValueOf(any)
 	attr := chainingAttrs[0]
-	if reflect.Indirect(rv).Kind() == reflect.Struct {
-		field := reflect.Indirect(rv).FieldByName(attr)
-		if field.IsValid() {
-			return nestedValue(ctx, field.Interface(), chainingAttrs[1:])
-		}
-	}
 
 	meth, err := findMethod(rv, attr)
 	if err != nil {
+		if reflect.Indirect(rv).Kind() == reflect.Struct {
+			field := reflect.Indirect(rv).FieldByName(attr)
+			if field.IsValid() {
+				return nestedValue(ctx, field.Interface(), chainingAttrs[1:])
+			}
+		}
+
 		// ignore method not found here.
 		// do nothing for mismatched fields.
 		logger.Warnf("[portal.nestedValue] %s", err)

--- a/utils_test.go
+++ b/utils_test.go
@@ -26,6 +26,18 @@ func (c *Car) Country() Country {
 	return Country{"China"}
 }
 
+type BigCar struct {
+	Car
+}
+
+func (bc *BigCar) Name() string {
+	return "big car"
+}
+
+func (bc *BigCar) Kind() MessageKind {
+	return MessageKind(2)
+}
+
 func TestGetNestedValue_Ok(t *testing.T) {
 	ctx := context.TODO()
 
@@ -50,6 +62,15 @@ func TestGetNestedValue_Ok(t *testing.T) {
 	r, e = nestedValue(ctx, &c, []string{"Kind", "Alias"})
 	assert.Nil(t, e)
 	assert.Equal(t, "alias_ok", r)
+
+	bigCar := &BigCar{Car: c}
+	r, e = nestedValue(ctx, bigCar, []string{"Name"})
+	assert.Nil(t, e)
+	assert.Equal(t, "big car", r)
+
+	r, e = nestedValue(ctx, bigCar, []string{"Kind", "Alias"})
+	assert.Nil(t, e)
+	assert.Equal(t, "alias_failed", r)
 }
 
 func TestGetNestedValue_Error(t *testing.T) {


### PR DESCRIPTION
Example:
```go
type BaseModel struct {
    Name string
}

type FooModel struct {
    BaseModel
}

func (f *FooModel) Name() string {
    return "custom name"
}

// portal will read value from the above method, get your custom name.
portal.Dump(&dst, &fooModel)
```